### PR TITLE
Make JavaScriptUserConfig compatible with new Django 1.10-style middleware and old style.

### DIFF
--- a/javascript_settings/middleware.py
+++ b/javascript_settings/middleware.py
@@ -1,4 +1,7 @@
-class JavaScriptUserConfig(object):
+from django.utils.deprecation import MiddlewareMixin
+
+
+class JavaScriptUserConfig(MiddlewareMixin):
     """ 
         Adds abbility to add parameters to javascript_settings
         from view.


### PR DESCRIPTION
[Upgrading pre-Django 1.10-style middleware](https://docs.djangoproject.com/en/1.10/topics/http/middleware/#upgrading-pre-django-1-10-style-middleware)